### PR TITLE
feat: add Claude Code session adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Herdr](https://herdr.dev) plugin that shows **live token spend** across all y
 - **Live dashboard** — Bubble Tea TUI with Lip Gloss styling, auto-refreshing every 3 seconds
 - **Per-agent breakdown** — cost, tokens (input/output/reasoning/cache), model, provider, session duration, message count, tool call stats
 - **Cost notifications** — Herdr native toast when an agent transitions to `done`, with cost and token summary
-- **Multi-agent support** — tracks both [Pi](https://github.com/nicepkg/pi) and [OpenCode](https://opencode.ai) agent sessions
+- **Multi-agent support** — tracks [Pi](https://github.com/nicepkg/pi), [OpenCode](https://opencode.ai), and [Claude Code](https://claude.com/claude-code) agent sessions
 - **Keybinding** — `prefix+$` opens the dashboard instantly
 
 ## Data Sources
@@ -19,6 +19,15 @@ A [Herdr](https://herdr.dev) plugin that shows **live token spend** across all y
 | Pi | Session JSONL (`agent_session.path`) | `sessionCostUsd`, model from `model_change`, message count, compaction count, session duration |
 | OpenCode (active) | Server API `http://127.0.0.1:4096/session/{id}` | Live cost, full token breakdown, model, provider, message count, tool calls |
 | OpenCode (completed) | Disk fallback `~/.local/share/opencode/storage/message/{id}/` | Same data from persisted message files |
+| Claude Code | Session transcript `~/.claude/projects/{project}/{session-id}.jsonl` | Full token breakdown (input/output/cache read/cache write), estimated cost, model, message count, tool calls, session duration |
+
+### Claude Code
+
+Claude Code panes are matched by their Herdr `agent_session` (source `herdr:claude`) and read from the session transcript JSONL that Claude Code writes under `~/.claude/projects/`. The transcript directory is derived from the pane's working directory; if that lookup misses (e.g. the pane changed directories after launch), the dashboard falls back to searching all project directories for the session ID.
+
+Streamed and retried transcript entries are deduplicated per assistant message, so token counts reflect actual API usage.
+
+> **Note:** Claude Code transcripts don't record cost, so the dashboard computes an **estimate** from a built-in pricing table (per-MTok list rates for current Anthropic models, including cache read/write multipliers). Unknown models show tokens but no cost. Rates live in one table in `main.go` and are easy to update.
 
 ## Install
 
@@ -73,7 +82,7 @@ Pane w2:p1 · msgs:38 · in:222.5k out:21.7k
 | Column | Description |
 |--------|-------------|
 | PANE | Compact pane ID |
-| AGENT | Agent name (pi / opencode) |
+| AGENT | Agent name (pi / opencode / claude) |
 | STATUS | Current agent status with colored dot |
 | COST | Session cost (green <$5, yellow <$25, red >$25) |
 | MODEL | Current model in use |
@@ -116,7 +125,7 @@ scripts/capture-dashboard-preview.py /tmp/dashboard.ansi docs/dashboard-preview.
 
 - [Herdr](https://herdr.dev) 0.7.0+
 - [Go](https://go.dev/) 1.22+ (for building from source)
-- [Pi](https://github.com/nicepkg/pi) and/or [OpenCode](https://opencode.ai) running in Herdr panes
+- [Pi](https://github.com/nicepkg/pi), [OpenCode](https://opencode.ai), and/or [Claude Code](https://claude.com/claude-code) running in Herdr panes
 
 ## Plugin Manifest
 
@@ -138,6 +147,8 @@ for each agent pane:
     Pi       → read JSONL → extract sessionCostUsd, model, messages, compactions
     OpenCode → query server API (127.0.0.1:4096) → extract cost, tokens, tools
               ↳ fallback to disk reads for completed sessions
+    Claude Code → read transcript JSONL (~/.claude/projects) → extract tokens,
+                  model, messages, tools; estimate cost from pricing table
     ↓
 aggregate per pane / workspace / total
     ↓

--- a/cmd/token-dashboard/claude_test.go
+++ b/cmd/token-dashboard/claude_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testSessionID = "5f0a3c1e-2b4d-4f6a-8c9e-0d1e2f3a4b5c"
+
+// withClaudeProjectsRoot points the Claude transcript lookup at a temp
+// fixture root for the duration of one test.
+func withClaudeProjectsRoot(t *testing.T, root string) {
+	t.Helper()
+	orig := claudeProjectsRoot
+	claudeProjectsRoot = func() string { return root }
+	t.Cleanup(func() { claudeProjectsRoot = orig })
+}
+
+// writeTranscript writes a JSONL fixture under root/dir/<sessionID>.jsonl.
+func writeTranscript(t *testing.T, root, dir string, lines []string) {
+	t.Helper()
+	projDir := filepath.Join(root, dir)
+	if err := os.MkdirAll(projDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(projDir, testSessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadClaudeSession(t *testing.T) {
+	cases := []struct {
+		name         string
+		dir          string // project dir under the fixture root; "" = munged cwd
+		cwd          string
+		lines        []string
+		wantMsgs     int
+		wantIn       int
+		wantOut      int
+		wantCacheR   int
+		wantCacheW   int
+		wantCost     float64
+		wantModel    string
+		wantProvider string
+		wantTools    map[string]int
+		wantDuration time.Duration
+	}{
+		{
+			name: "normal session",
+			cwd:  "/home/user/projects/demo",
+			lines: []string{
+				`{"type":"user","timestamp":"2026-07-13T10:00:00.000Z","message":{"role":"user","content":"hello"}}`,
+				`{"type":"assistant","timestamp":"2026-07-13T10:00:05.000Z","requestId":"req_01","message":{"id":"msg_01","model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":500,"cache_read_input_tokens":2000,"cache_creation_input_tokens":3000,"service_tier":"standard"},"content":[{"type":"text","text":"hi"}]}}`,
+				`{"type":"assistant","timestamp":"2026-07-13T10:05:00.000Z","requestId":"req_02","message":{"id":"msg_02","model":"claude-opus-4-8","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"tool_use","id":"toolu_01","name":"Bash"},{"type":"tool_use","id":"toolu_02","name":"Read"}]}}`,
+			},
+			wantMsgs:   2,
+			wantIn:     1100,
+			wantOut:    550,
+			wantCacheR: 2000,
+			wantCacheW: 3000,
+			// opus-4: (1000*15 + 500*75 + 2000*1.5 + 3000*18.75)/1e6
+			//       + (100*15 + 50*75)/1e6
+			wantCost:     0.11175 + 0.00525,
+			wantModel:    "claude-opus-4-8",
+			wantProvider: "anthropic",
+			wantTools:    map[string]int{"Bash": 1, "Read": 1},
+			wantDuration: 5 * time.Minute,
+		},
+		{
+			name: "dedupe repeated message id and requestId",
+			cwd:  "/home/user/projects/demo",
+			lines: []string{
+				`{"type":"assistant","timestamp":"2026-07-13T11:00:00.000Z","requestId":"req_01","message":{"id":"msg_01","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"tool_use","id":"toolu_x","name":"Bash"}]}}`,
+				`{"type":"assistant","timestamp":"2026-07-13T11:00:03.000Z","requestId":"req_01","message":{"id":"msg_01","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"tool_use","id":"toolu_x","name":"Bash"}]}}`,
+			},
+			wantMsgs: 1,
+			wantIn:   100,
+			wantOut:  200,
+			// sonnet-4-5, last occurrence wins: (100*3 + 200*15)/1e6
+			wantCost:     0.0033,
+			wantModel:    "claude-sonnet-4-5",
+			wantProvider: "anthropic",
+			wantTools:    map[string]int{"Bash": 1},
+			wantDuration: 3 * time.Second,
+		},
+		{
+			name: "unknown model has zero cost but tokens are kept",
+			cwd:  "/home/user/projects/demo",
+			lines: []string{
+				`{"type":"assistant","timestamp":"2026-07-13T12:00:00.000Z","requestId":"req_01","message":{"id":"msg_01","model":"claude-zeta-9","usage":{"input_tokens":1000,"output_tokens":1000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"text","text":"hi"}]}}`,
+			},
+			wantMsgs:     1,
+			wantIn:       1000,
+			wantOut:      1000,
+			wantCost:     0,
+			wantModel:    "claude-zeta-9",
+			wantProvider: "anthropic",
+			wantTools:    map[string]int{},
+		},
+		{
+			name: "glob fallback when munged cwd path misses",
+			dir:  "-home-user-projects-old-location",
+			cwd:  "/home/user/projects/moved-since-launch",
+			lines: []string{
+				`{"type":"assistant","timestamp":"2026-07-13T13:00:00.000Z","requestId":"req_01","message":{"id":"msg_01","model":"claude-haiku-4-5","usage":{"input_tokens":500,"output_tokens":100,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"text","text":"hi"}]}}`,
+			},
+			wantMsgs: 1,
+			wantIn:   500,
+			wantOut:  100,
+			// haiku-4-5: (500*1 + 100*5)/1e6
+			wantCost:     0.001,
+			wantModel:    "claude-haiku-4-5",
+			wantProvider: "anthropic",
+			wantTools:    map[string]int{},
+		},
+		{
+			name: "malformed lines are skipped",
+			cwd:  "/home/user/projects/demo",
+			lines: []string{
+				`not json at all`,
+				`{"type":"assistant","message":`,
+				`{"type":"assistant","timestamp":"2026-07-13T14:00:00.000Z","requestId":"req_01","message":{"id":"msg_01","model":"claude-fable-5","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":"plain string content"}}`,
+				`{"type":"assistant"}`,
+			},
+			wantMsgs: 1,
+			wantIn:   10,
+			wantOut:  20,
+			// fable-5: (10*20 + 20*100)/1e6
+			wantCost:     0.0022,
+			wantModel:    "claude-fable-5",
+			wantProvider: "anthropic",
+			wantTools:    map[string]int{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			withClaudeProjectsRoot(t, root)
+
+			dir := tc.dir
+			if dir == "" {
+				dir = mungeClaudePath(tc.cwd)
+			}
+			writeTranscript(t, root, dir, tc.lines)
+
+			s := tokenStats{Tools: map[string]int{}}
+			readClaudeSession(testSessionID, tc.cwd, &s)
+
+			if s.Messages != tc.wantMsgs {
+				t.Errorf("Messages = %d, want %d", s.Messages, tc.wantMsgs)
+			}
+			if s.InputT != tc.wantIn {
+				t.Errorf("InputT = %d, want %d", s.InputT, tc.wantIn)
+			}
+			if s.OutputT != tc.wantOut {
+				t.Errorf("OutputT = %d, want %d", s.OutputT, tc.wantOut)
+			}
+			if s.CacheR != tc.wantCacheR {
+				t.Errorf("CacheR = %d, want %d", s.CacheR, tc.wantCacheR)
+			}
+			if s.CacheW != tc.wantCacheW {
+				t.Errorf("CacheW = %d, want %d", s.CacheW, tc.wantCacheW)
+			}
+			if math.Abs(s.Cost-tc.wantCost) > 1e-9 {
+				t.Errorf("Cost = %v, want %v", s.Cost, tc.wantCost)
+			}
+			if s.Model != tc.wantModel {
+				t.Errorf("Model = %q, want %q", s.Model, tc.wantModel)
+			}
+			if s.Provider != tc.wantProvider {
+				t.Errorf("Provider = %q, want %q", s.Provider, tc.wantProvider)
+			}
+			if s.Duration != tc.wantDuration {
+				t.Errorf("Duration = %v, want %v", s.Duration, tc.wantDuration)
+			}
+			if len(s.Tools) != len(tc.wantTools) {
+				t.Errorf("Tools = %v, want %v", s.Tools, tc.wantTools)
+			}
+			toolTotal := 0
+			for name, n := range tc.wantTools {
+				toolTotal += n
+				if s.Tools[name] != n {
+					t.Errorf("Tools[%q] = %d, want %d", name, s.Tools[name], n)
+				}
+			}
+			if s.ToolTotal != toolTotal {
+				t.Errorf("ToolTotal = %d, want %d", s.ToolTotal, toolTotal)
+			}
+		})
+	}
+}
+
+func TestReadClaudeSessionMissingTranscript(t *testing.T) {
+	withClaudeProjectsRoot(t, t.TempDir())
+
+	s := tokenStats{Tools: map[string]int{}}
+	readClaudeSession(testSessionID, "/home/user/projects/nowhere", &s)
+
+	if s.Messages != 0 || s.InputT != 0 || s.Cost != 0 {
+		t.Errorf("expected zero stats for missing transcript, got %+v", s)
+	}
+}
+
+func TestClaudeRates(t *testing.T) {
+	cases := []struct {
+		model  string
+		wantIn float64
+		wantOK bool
+	}{
+		{"claude-opus-4-8", 15, true},
+		{"claude-sonnet-4-5", 3, true},
+		{"claude-sonnet-4-20250514", 3, true},
+		{"claude-haiku-4-5", 1, true},
+		{"claude-fable-5", 20, true},
+		{"some-future-model", 0, false},
+		{"", 0, false},
+	}
+	for _, tc := range cases {
+		in, _, ok := claudeRates(tc.model)
+		if ok != tc.wantOK || in != tc.wantIn {
+			t.Errorf("claudeRates(%q) = (in=%v, ok=%v), want (in=%v, ok=%v)",
+				tc.model, in, ok, tc.wantIn, tc.wantOK)
+		}
+	}
+}
+
+func TestMungeClaudePath(t *testing.T) {
+	got := mungeClaudePath("/home/ajavaherian/projects/TMM-Workflow")
+	want := "-home-ajavaherian-projects-TMM-Workflow"
+	if got != want {
+		t.Errorf("mungeClaudePath = %q, want %q", got, want)
+	}
+	if got := mungeClaudePath("/tmp/a_b.c d"); got != "-tmp-a-b-c-d" {
+		t.Errorf("mungeClaudePath = %q, want %q", got, "-tmp-a-b-c-d")
+	}
+}

--- a/cmd/token-dashboard/main.go
+++ b/cmd/token-dashboard/main.go
@@ -59,8 +59,9 @@ var (
 			Foreground(yellow)
 
 	// Badges
-	piBadge = lipgloss.NewStyle().Foreground(purple).Bold(true)
-	ocBadge = lipgloss.NewStyle().Foreground(green).Bold(true)
+	piBadge     = lipgloss.NewStyle().Foreground(purple).Bold(true)
+	ocBadge     = lipgloss.NewStyle().Foreground(green).Bold(true)
+	claudeBadge = lipgloss.NewStyle().Foreground(orange).Bold(true)
 
 	// Cost tiers
 	costLow   = lipgloss.NewStyle().Foreground(green)
@@ -331,6 +332,8 @@ func agentBadge(agent string) string {
 		return piBadge.Render("pi")
 	case "opencode":
 		return ocBadge.Render("opencode")
+	case "claude":
+		return claudeBadge.Render("claude")
 	default:
 		return labelStyle.Render(fallback(agent, "—"))
 	}
@@ -849,6 +852,9 @@ func extractStats(p paneEntry) tokenStats {
 	case "herdr:opencode":
 		s.Source = "opencode"
 		readOpenCodeLive(p.AgentSession.Value, &s)
+	case "herdr:claude", "claude":
+		s.Source = "claude"
+		readClaudeSession(p.AgentSession.Value, p.Cwd, &s)
 	default:
 		if strings.HasSuffix(p.AgentSession.Value, ".jsonl") {
 			s.Source = "pi"
@@ -917,6 +923,216 @@ func readPiSession(path string, s *tokenStats) {
 			s.Compactions++
 		}
 	}
+
+	s.Started = firstTS
+	s.LastAct = lastTS
+	if !firstTS.IsZero() && !lastTS.IsZero() {
+		s.Duration = lastTS.Sub(firstTS)
+	}
+}
+
+// ── Claude Code sessions ────────────────────────────────────────────────────
+
+// claudePricing maps a model-id substring to estimated Anthropic per-MTok
+// USD rates. Prices are ESTIMATES based on public list pricing — update the
+// rates here when Anthropic pricing changes. Matching is by substring,
+// longest match first, so more specific entries (e.g. "sonnet-4-5") win over
+// broader ones ("sonnet-4"). Cache reads are billed at 0.1× the input rate,
+// cache writes at 1.25× the input rate. Unknown models get no cost estimate
+// (tokens are still shown).
+var claudePricing = []struct {
+	substr string
+	in     float64 // USD per MTok input
+	out    float64 // USD per MTok output
+}{
+	{"opus-4", 15, 75},
+	{"sonnet-4-5", 3, 15},
+	{"sonnet-4", 3, 15},
+	{"haiku-4-5", 1, 5},
+	{"fable-5", 20, 100},
+}
+
+// claudeRates returns the estimated per-MTok rates for a model id, matching
+// pricing-table substrings longest-first. ok is false for unknown models.
+func claudeRates(model string) (in, out float64, ok bool) {
+	best := -1
+	for _, p := range claudePricing {
+		if strings.Contains(model, p.substr) && len(p.substr) > best {
+			best = len(p.substr)
+			in, out = p.in, p.out
+			ok = true
+		}
+	}
+	return in, out, ok
+}
+
+// claudeCost estimates the USD cost of one assistant turn.
+func claudeCost(model string, input, output, cacheRead, cacheWrite int) float64 {
+	in, out, ok := claudeRates(model)
+	if !ok {
+		return 0
+	}
+	return (float64(input)*in +
+		float64(output)*out +
+		float64(cacheRead)*0.1*in +
+		float64(cacheWrite)*1.25*in) / 1_000_000
+}
+
+// claudeProjectsRoot returns the Claude Code projects directory
+// (~/.claude/projects). A variable so tests can point it at a fixture dir.
+var claudeProjectsRoot = func() string {
+	h := homeDir()
+	if h == "" {
+		return ""
+	}
+	return filepath.Join(h, ".claude", "projects")
+}
+
+// mungeClaudePath converts a working directory into the directory name
+// Claude Code uses under ~/.claude/projects: every character outside
+// [A-Za-z0-9-] is replaced by '-'.
+func mungeClaudePath(p string) string {
+	var b strings.Builder
+	for _, r := range p {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// claudeSessionPath locates the transcript for a Claude Code session. The
+// munged-cwd path is tried first; if it misses (e.g. the pane cwd changed
+// after launch), fall back to globbing every project dir — session UUIDs
+// are unique.
+func claudeSessionPath(sessionID, cwd string) string {
+	root := claudeProjectsRoot()
+	if root == "" || sessionID == "" {
+		return ""
+	}
+	if cwd != "" {
+		p := filepath.Join(root, mungeClaudePath(cwd), sessionID+".jsonl")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", sessionID+".jsonl"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+// readClaudeSession reads a Claude Code session transcript JSONL and
+// extracts tokens, estimated cost, model, message count, tool calls, and
+// session duration. Streaming and retries can repeat records for the same
+// assistant message, so usage is aggregated per (message.id, requestId)
+// pair — each unique pair counts once, last occurrence wins.
+func readClaudeSession(sessionID, cwd string, s *tokenStats) {
+	path := claudeSessionPath(sessionID, cwd)
+	if path == "" {
+		debugLog("claude transcript not found for session " + sessionID)
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	type claudeTurn struct {
+		model                         string
+		input, output, cacheR, cacheW int
+	}
+	turns := map[string]claudeTurn{}
+	seenTools := map[string]bool{}
+	var firstTS, lastTS time.Time
+
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Type      string `json:"type"`
+			Timestamp string `json:"timestamp"`
+			RequestID string `json:"requestId"`
+			Message   struct {
+				ID    string `json:"id"`
+				Model string `json:"model"`
+				Usage struct {
+					InputTokens              int `json:"input_tokens"`
+					OutputTokens             int `json:"output_tokens"`
+					CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+					CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if json.Unmarshal(line, &entry) != nil {
+			continue
+		}
+
+		if entry.Timestamp != "" {
+			if ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp); err == nil {
+				if firstTS.IsZero() {
+					firstTS = ts
+				}
+				lastTS = ts
+			}
+		}
+
+		if entry.Type != "assistant" || entry.Message.ID == "" {
+			continue
+		}
+
+		if entry.Message.Model != "" {
+			s.Model = entry.Message.Model
+			s.Provider = "anthropic"
+		}
+
+		turns[entry.Message.ID+"\x00"+entry.RequestID] = claudeTurn{
+			model:  entry.Message.Model,
+			input:  entry.Message.Usage.InputTokens,
+			output: entry.Message.Usage.OutputTokens,
+			cacheR: entry.Message.Usage.CacheReadInputTokens,
+			cacheW: entry.Message.Usage.CacheCreationInputTokens,
+		}
+
+		// Tool calls appear as tool_use content blocks. Blocks carry unique
+		// ids, so repeated records for the same message don't double-count.
+		var blocks []struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		if len(entry.Message.Content) == 0 || json.Unmarshal(entry.Message.Content, &blocks) != nil {
+			continue
+		}
+		for _, blk := range blocks {
+			if blk.Type != "tool_use" || blk.Name == "" {
+				continue
+			}
+			if blk.ID != "" {
+				if seenTools[blk.ID] {
+					continue
+				}
+				seenTools[blk.ID] = true
+			}
+			s.Tools[blk.Name]++
+			s.ToolTotal++
+		}
+	}
+
+	for _, t := range turns {
+		s.InputT += t.input
+		s.OutputT += t.output
+		s.CacheR += t.cacheR
+		s.CacheW += t.cacheW
+		s.Cost += claudeCost(t.model, t.input, t.output, t.cacheR, t.cacheW)
+	}
+	s.Messages = len(turns)
 
 	s.Started = firstTS
 	s.LastAct = lastTS


### PR DESCRIPTION
## Summary

Adds a **Claude Code** session adapter so the token dashboard tracks Claude Code panes alongside Pi and OpenCode.

Panes whose `agent_session` source is `herdr:claude` are read from the Claude Code session transcript JSONL at `~/.claude/projects/<munged-cwd>/<session>.jsonl`, with a glob fallback across project dirs when the munged path doesn't resolve.

## What it does

- Full token breakdown (input / output / cache read / cache write), model, message count, tool calls, and session duration parsed from the transcript
- Streamed/retried entries deduped per `(message.id, requestId)` pair; `tool_use` blocks deduped by block id
- Estimated cost from a built-in per-MTok pricing table (list rates, cache read 0.1×, cache write 1.25× input); unknown models show tokens with no cost
- Claude panes flow through the existing done-transition cost notifications
- Table-driven tests covering parsing, dedupe, unknown models, path fallback, and malformed lines

## Files

- `cmd/token-dashboard/main.go` — adapter + pricing/dedup logic
- `cmd/token-dashboard/claude_test.go` — table-driven tests
- `README.md` — Claude Code section

## Caveats for review

Flagging these openly so you can decide how you'd like them handled:

1. **Hardcoded pricing table.** Costs come from a built-in per-MTok table baked into the binary. It will drift as models/prices change, and unknown models intentionally fall back to tokens-only (no cost). Happy to move this to config or make it more clearly overridable if you'd prefer.
2. **Retry/dedup semantics.** Dedup is keyed on `(message.id, requestId)` for entries and block id for `tool_use`. This is designed to avoid double-counting streamed/retried lines, but the exact retry behavior of the transcript format is the main thing worth a careful look.
3. **debugLog chattiness.** The adapter emits fairly verbose debug logging along the parse path. Can dial that down or gate it behind a flag if it's noisier than the existing adapters.

Feedback welcome on all three — glad to adjust to match how you'd rather structure adapters.
