### PR TITLE
Fix Claude pricing table: missing Opus 5 / Sonnet 5, and two over-billed entries

### DIFF
--- a/cmd/token-dashboard/claude_test.go
+++ b/cmd/token-dashboard/claude_test.go
@@ -63,9 +63,10 @@ func TestReadClaudeSession(t *testing.T) {
 			wantOut:    550,
 			wantCacheR: 2000,
 			wantCacheW: 3000,
-			// opus-4: (1000*15 + 500*75 + 2000*1.5 + 3000*18.75)/1e6
-			//       + (100*15 + 50*75)/1e6
-			wantCost:     0.11175 + 0.00525,
+			// opus-4-8 at $5/$25 (cache read 0.1x in, cache write 1.25x in):
+			// (1000*5 + 500*25 + 2000*0.5 + 3000*6.25)/1e6
+			//       + (100*5 + 50*25)/1e6
+			wantCost:     0.03725 + 0.00175,
 			wantModel:    "claude-opus-4-8",
 			wantProvider: "anthropic",
 			wantTools:    map[string]int{"Bash": 1, "Read": 1},
@@ -130,8 +131,8 @@ func TestReadClaudeSession(t *testing.T) {
 			wantMsgs: 1,
 			wantIn:   10,
 			wantOut:  20,
-			// fable-5: (10*20 + 20*100)/1e6
-			wantCost:     0.0022,
+			// fable-5: (10*10 + 20*50)/1e6
+			wantCost:     0.0011,
 			wantModel:    "claude-fable-5",
 			wantProvider: "anthropic",
 			wantTools:    map[string]int{},
@@ -213,11 +214,14 @@ func TestClaudeRates(t *testing.T) {
 		wantIn float64
 		wantOK bool
 	}{
-		{"claude-opus-4-8", 15, true},
+		{"claude-opus-4-8", 5, true},
+		{"claude-opus-5", 5, true},
+		{"claude-sonnet-5", 3, true},
+		{"claude-opus-4-1", 15, true},
 		{"claude-sonnet-4-5", 3, true},
 		{"claude-sonnet-4-20250514", 3, true},
 		{"claude-haiku-4-5", 1, true},
-		{"claude-fable-5", 20, true},
+		{"claude-fable-5", 10, true},
 		{"some-future-model", 0, false},
 		{"", 0, false},
 	}

--- a/cmd/token-dashboard/main.go
+++ b/cmd/token-dashboard/main.go
@@ -945,11 +945,22 @@ var claudePricing = []struct {
 	in     float64 // USD per MTok input
 	out    float64 // USD per MTok output
 }{
+	{"opus-5", 5, 25},
+	{"sonnet-5", 3, 15},
+	{"fable-5", 10, 50},
+	{"mythos-5", 10, 50},
+	// Opus 4.5 through 4.8 are $5/$25 — they must be listed explicitly, because
+	// the bare "opus-4" entry below substring-matches them and would otherwise
+	// price them at the legacy Opus 4 / 4.1 rate.
+	{"opus-4-8", 5, 25},
+	{"opus-4-7", 5, 25},
+	{"opus-4-6", 5, 25},
+	{"opus-4-5", 5, 25},
 	{"opus-4", 15, 75},
+	{"sonnet-4-6", 3, 15},
 	{"sonnet-4-5", 3, 15},
 	{"sonnet-4", 3, 15},
 	{"haiku-4-5", 1, 5},
-	{"fable-5", 20, 100},
 }
 
 // claudeRates returns the estimated per-MTok rates for a model id, matching


### PR DESCRIPTION
Ran the dashboard across nine Claude Code panes and the cost column was wrong in three different ways. All three fail quietly — `claudeRates` returns `ok=false` on no match, so a missing model renders a blank cost rather than an error, and a wrong rate just renders a wrong number.

| Model | Current | Actual | Effect |
|---|---|---|---|
| `claude-opus-5` | *no entry* | $5 / $25 | tokens shown, **cost blank** |
| `claude-sonnet-5` | *no entry* | $3 / $15 | tokens shown, **cost blank** |
| `claude-fable-5` | $20 / $100 | $10 / $50 | **2× over** |
| `claude-opus-4-8` (via `opus-4`) | $15 / $75 | $5 / $25 | **3× over** |

The third one is the subtle one. Matching is longest-substring-first, and the bare `opus-4` entry substring-matches `claude-opus-4-5`, `-4-6`, `-4-7`, and `-4-8` — all of which are $5/$25 — pricing them at the legacy Opus 4 / 4.1 rate. Adding explicit longer entries fixes it through the existing match logic; `opus-4` still covers genuine Opus 4 / 4.1, and there's a new test case pinning that.

Also adds `sonnet-4-6` and `mythos-5` for completeness. Rates are Anthropic first-party list pricing per MTok; the existing cache multipliers (0.1× read, 1.25× write) are untouched.

### Tests

Three existing expectations pinned the old rates, so they're updated rather than removed:

- `TestReadClaudeSession/normal_session` — recomputed for opus-4-8 at $5/$25
- `TestReadClaudeSession/malformed_lines_are_skipped` — recomputed for fable-5 at $10/$50
- `TestClaudeRates` — corrected, plus new cases for `claude-opus-5`, `claude-sonnet-5`, and `claude-opus-4-1`

`go test ./...` passes and `gofmt` is clean.

Sent separately from #(the PANE column change) so this one isn't blocked on a design discussion — happy to combine them if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)