### PR TITLE
Show the tab label in the PANE column, falling back to the pane id

### DIFF
--- a/cmd/token-dashboard/main.go
+++ b/cmd/token-dashboard/main.go
@@ -102,6 +102,7 @@ type paneEntry struct {
 	Agent        string        `json:"agent,omitempty"`
 	AgentStatus  string        `json:"agent_status,omitempty"`
 	Label        string        `json:"label,omitempty"`
+	TabID        string        `json:"tab_id,omitempty"`
 	Cwd          string        `json:"cwd,omitempty"`
 	AgentSession *agentSession `json:"agent_session,omitempty"`
 }
@@ -145,6 +146,7 @@ type tokenStats struct {
 	Tools       map[string]int
 	ToolTotal   int
 	Title       string
+	TabLabel    string
 }
 
 // OpenCode server API response types.
@@ -498,7 +500,7 @@ func renderTable(stats []tokenStats, total tokenStats, width int) string {
 		}
 
 		rowParts := []string{
-			padRight(shortPaneID(s.PaneID), wPane),
+			padRight(paneDisplay(s), wPane),
 			padRight(agentBadge(s.Agent), wAgent),
 			padRight(statusStr, wStatus),
 			padRight(costS.Render(costStr), wCost),
@@ -562,6 +564,12 @@ func renderCard(s tokenStats, width int) string {
 	// Card with left border
 	var inner strings.Builder
 	inner.WriteString(headerLine + "\n")
+
+	// Pane id — the table column may be showing the tab label instead.
+	inner.WriteString(fmt.Sprintf("  %s %s\n",
+		labelStyle.Render("pane:"),
+		valueStyle.Render(shortPaneID(s.PaneID)),
+	))
 
 	// Title
 	if s.Title != "" {
@@ -819,8 +827,51 @@ func fetchPanes() ([]paneEntry, error) {
 	return resp.Result.Panes, nil
 }
 
+// fetchTabLabels maps tab_id -> tab label. Best effort: on any failure it
+// returns an empty map and the PANE column falls back to the short pane id.
+func fetchTabLabels() map[string]string {
+	labels := map[string]string{}
+	herdr := os.Getenv("HERDR_BIN_PATH")
+	if herdr == "" {
+		herdr = "herdr"
+	}
+	cmd := exec.Command(herdr, "tab", "list")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return labels
+	}
+	var resp struct {
+		Result struct {
+			Tabs []struct {
+				TabID string `json:"tab_id"`
+				Label string `json:"label"`
+			} `json:"tabs"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return labels
+	}
+	for _, t := range resp.Result.Tabs {
+		if t.Label != "" {
+			labels[t.TabID] = t.Label
+		}
+	}
+	return labels
+}
+
+// paneDisplay is the PANE column value: the tab label when the pane's tab has
+// one, else the short pane id.
+func paneDisplay(s tokenStats) string {
+	if s.TabLabel != "" {
+		return s.TabLabel
+	}
+	return shortPaneID(s.PaneID)
+}
+
 func collectStats(panes []paneEntry) []tokenStats {
 	var stats []tokenStats
+	tabLabels := fetchTabLabels()
 	for _, p := range panes {
 		if p.AgentSession == nil {
 			continue
@@ -828,6 +879,7 @@ func collectStats(panes []paneEntry) []tokenStats {
 		s := extractStats(p)
 		s.Status = p.AgentStatus
 		s.Cwd = p.Cwd
+		s.TabLabel = tabLabels[p.TabID]
 		stats = append(stats, s)
 	}
 	sort.Slice(stats, func(i, j int) bool { return stats[i].Cost > stats[j].Cost })


### PR DESCRIPTION
With several agents running, a column of pane ids gives no way to tell which row is which piece of work — reading the table means cross-referencing every id against the sidebar.

The tab label is already the human-meaningful name for a pane's work: herdr sets it, users rename it, and in agent workflows it often carries a ticket id. This joins `pane.tab_id` to the label from `herdr tab list` and shows it in the PANE column.

Before:

```
  PANE        AGENT     STATUS    COST      MODEL          MSGS   TOOLS
  w3:p4       claude    ● working $42.59    claude-opus-5  219    231
  w3:pC       claude    ● working $24.41    claude-opus-5  156    178
  w3:p2       claude    ● working $21.58    claude-opus-5  168    161
```

After:

```
  PANE        AGENT     STATUS    COST      MODEL          MSGS   TOOLS
  SHA-673     claude    ● working $42.59    claude-opus-5  219    231
  terminal    claude    ● working $24.41    claude-opus-5  156    178
  SHA-571     claude    ● working $21.58    claude-opus-5  168    161
```

Notes on the approach:

- **Falls back, never blanks.** `fetchTabLabels` is best effort — if `herdr tab list` can't run or parse, it returns an empty map and every row falls back to `shortPaneID`, exactly as today. A tab with no label (`terminal` above is a labelled one; an unlabelled tab shows its pane id) falls back per-row.
- **Nothing is lost.** The pane id moves into the detail card as a `pane:` line.
- **Cost is one extra CLI call per refresh**, alongside the existing `herdr pane list`. Happy to fold it into the same poll differently if you'd rather.
- No new dependencies; `go test ./...` passes, `gofmt` and `go vet` clean.

Sent separately from #2 (the pricing-table bug fix) since that one is a straightforward correction and this is a presentation change you may have opinions on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)