### PR TITLE
Add Codex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Herdr](https://herdr.dev) plugin that shows **live token spend** across all y
 - **Live dashboard** — Bubble Tea TUI with Lip Gloss styling, auto-refreshing every 3 seconds
 - **Per-agent breakdown** — cost, tokens (input/output/reasoning/cache), model, provider, session duration, message count, tool call stats
 - **Cost notifications** — Herdr native toast when an agent transitions to `done`, with cost and token summary
-- **Multi-agent support** — tracks [Pi](https://github.com/nicepkg/pi), [OpenCode](https://opencode.ai), and [Claude Code](https://claude.com/claude-code) agent sessions
+- **Multi-agent support** — tracks [Pi](https://github.com/nicepkg/pi), [OpenCode](https://opencode.ai), [Claude Code](https://claude.com/claude-code), and [Codex](https://github.com/openai/codex) agent sessions
 - **Keybinding** — `prefix+$` opens the dashboard instantly
 
 ## Data Sources
@@ -20,6 +20,7 @@ A [Herdr](https://herdr.dev) plugin that shows **live token spend** across all y
 | OpenCode (active) | Server API `http://127.0.0.1:4096/session/{id}` | Live cost, full token breakdown, model, provider, message count, tool calls |
 | OpenCode (completed) | Disk fallback `~/.local/share/opencode/storage/message/{id}/` | Same data from persisted message files |
 | Claude Code | Session transcript `~/.claude/projects/{project}/{session-id}.jsonl` | Full token breakdown (input/output/cache read/cache write), estimated cost, model, message count, tool calls, session duration |
+| Codex | Rollout `~/.codex/sessions/YYYY/MM/DD/rollout-*-{session-id}.jsonl` | Full token breakdown, estimated cost, model, message count, tool calls, session duration |
 
 ### Claude Code
 
@@ -28,6 +29,19 @@ Claude Code panes are matched by their Herdr `agent_session` (source `herdr:clau
 Streamed and retried transcript entries are deduplicated per assistant message, so token counts reflect actual API usage.
 
 > **Note:** Claude Code transcripts don't record cost, so the dashboard computes an **estimate** from a built-in pricing table (per-MTok list rates for current Anthropic models, including cache read/write multipliers). Unknown models show tokens but no cost. Rates live in one table in `main.go` and are easy to update.
+
+### Codex
+
+Codex panes are matched by their Herdr `agent_session` (source `herdr:codex`) and read from the rollout JSONL under `~/.codex/sessions/` (or `$CODEX_HOME/sessions`). The session ID is matched on the rollout filename; if that misses, the `session_meta` line is read instead.
+
+Two Codex-specific details:
+
+- Codex reports **cumulative** totals on every `token_count` event, so the last event wins rather than being summed.
+- Codex's `input_tokens` is **inclusive** of `cached_input_tokens`, unlike the other sources here. The cached portion is subtracted so the IN and CACHE columns mean the same thing for every agent and the totals row stays additive.
+
+Cost is estimated from a second table of OpenAI list rates, scoped to the `gpt-5` family that Codex runs. Those models price cached input at 0.1x input and cache writes at 1.25x — the same multipliers the Anthropic table uses — so both providers share one cost function. Older families are deliberately omitted: `gpt-4.1` caches at 0.25x and `gpt-4o` at 0.5x, so costing them with these multipliers would be wrong, and no rate is better than a wrong one.
+
+> **Note:** long-context rates (roughly double) are not modelled. They apply above a context length larger than the window Codex reports (258,400 for `gpt-5.6-sol`), so a Codex turn cannot reach that tier.
 
 ## Install
 
@@ -82,7 +96,7 @@ Pane w2:p1 · msgs:38 · in:222.5k out:21.7k
 | Column | Description |
 |--------|-------------|
 | PANE | Compact pane ID |
-| AGENT | Agent name (pi / opencode / claude) |
+| AGENT | Agent name (pi / opencode / claude / codex) |
 | STATUS | Current agent status with colored dot |
 | COST | Session cost (green <$5, yellow <$25, red >$25) |
 | MODEL | Current model in use |

--- a/cmd/token-dashboard/codex.go
+++ b/cmd/token-dashboard/codex.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// codexSessionsRoot returns the directory Codex writes rollouts under.
+func codexSessionsRoot() string {
+	if custom := os.Getenv("CODEX_HOME"); custom != "" {
+		return filepath.Join(custom, "sessions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codex", "sessions")
+}
+
+// codexRolloutPath locates the rollout for a session id. Codex lays rollouts
+// out as sessions/YYYY/MM/DD/rollout-<timestamp>-<session-id>.jsonl, so the id
+// is matched on the filename suffix; if that misses (a layout change, or a
+// session id that is not in the name) the session_meta line is checked instead.
+func codexRolloutPath(sessionID string) string {
+	root := codexSessionsRoot()
+	if root == "" || sessionID == "" {
+		return ""
+	}
+
+	matches, err := filepath.Glob(filepath.Join(root, "*", "*", "*", "rollout-*"+sessionID+".jsonl"))
+	if err == nil && len(matches) > 0 {
+		return matches[0]
+	}
+
+	candidates, err := filepath.Glob(filepath.Join(root, "*", "*", "*", "rollout-*.jsonl"))
+	if err != nil {
+		return ""
+	}
+	for _, candidate := range candidates {
+		if codexRolloutSessionID(candidate) == sessionID {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// codexRolloutSessionID reads the session id from a rollout's session_meta,
+// which is the first line.
+func codexRolloutSessionID(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.SplitN(string(data), "\n", 8) {
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Type    string `json:"type"`
+			Payload struct {
+				SessionID string `json:"session_id"`
+				ID        string `json:"id"`
+			} `json:"payload"`
+		}
+		if json.Unmarshal([]byte(line), &entry) != nil || entry.Type != "session_meta" {
+			continue
+		}
+		if entry.Payload.SessionID != "" {
+			return entry.Payload.SessionID
+		}
+		return entry.Payload.ID
+	}
+	return ""
+}
+
+// readCodexSession reads a Codex rollout JSONL and extracts tokens, model,
+// message count, tool calls, and session duration.
+//
+// Codex reports cumulative totals on every token_count event, so the last one
+// wins rather than being summed — unlike Pi and Claude, where per-message usage
+// is accumulated.
+//
+// No cost is set: the pricing table in main.go covers Anthropic models only,
+// and inventing OpenAI rates here would produce a confidently wrong number.
+// Unknown-model behaviour already renders tokens with a blank cost.
+func readCodexSession(sessionID string, s *tokenStats) {
+	path := codexRolloutPath(sessionID)
+	if path == "" {
+		debugLog("codex rollout not found for session " + sessionID)
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		debugLog("codex rollout unreadable: " + err.Error())
+		return
+	}
+
+	var firstTS, lastTS time.Time
+
+	for _, raw := range strings.Split(string(data), "\n") {
+		if raw == "" {
+			continue
+		}
+		var entry struct {
+			Type      string          `json:"type"`
+			Timestamp string          `json:"timestamp"`
+			Payload   json.RawMessage `json:"payload"`
+		}
+		if json.Unmarshal([]byte(raw), &entry) != nil {
+			continue
+		}
+
+		if ts, err := time.Parse(time.RFC3339, entry.Timestamp); err == nil {
+			if firstTS.IsZero() || ts.Before(firstTS) {
+				firstTS = ts
+			}
+			if ts.After(lastTS) {
+				lastTS = ts
+			}
+		}
+
+		switch entry.Type {
+		case "session_meta":
+			var meta struct {
+				Cwd string `json:"cwd"`
+			}
+			if json.Unmarshal(entry.Payload, &meta) == nil && meta.Cwd != "" && s.Cwd == "" {
+				s.Cwd = meta.Cwd
+			}
+		case "turn_context", "world_state":
+			// turn_context carries the model for the active turn; world_state is
+			// the fallback for rollouts that predate it.
+			var ctx struct {
+				Model string `json:"model"`
+			}
+			if json.Unmarshal(entry.Payload, &ctx) == nil && ctx.Model != "" {
+				s.Model = ctx.Model
+			}
+		case "event_msg":
+			var msg struct {
+				Type string `json:"type"`
+				Info struct {
+					TotalTokenUsage struct {
+						InputTokens           int `json:"input_tokens"`
+						CachedInputTokens     int `json:"cached_input_tokens"`
+						CacheWriteInputTokens int `json:"cache_write_input_tokens"`
+						OutputTokens          int `json:"output_tokens"`
+						ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+					} `json:"total_token_usage"`
+					ModelContextWindow int `json:"model_context_window"`
+				} `json:"info"`
+			}
+			if json.Unmarshal(entry.Payload, &msg) != nil {
+				continue
+			}
+			switch msg.Type {
+			case "token_count":
+				usage := msg.Info.TotalTokenUsage
+				// Codex's input_tokens is INCLUSIVE of cached_input_tokens,
+				// whereas this dashboard's other sources report uncached input.
+				// Subtract so the IN and CACHE columns mean the same thing for
+				// every agent and the totals row stays additive.
+				uncached := usage.InputTokens - usage.CachedInputTokens - usage.CacheWriteInputTokens
+				if uncached < 0 {
+					uncached = 0
+				}
+				s.InputT = uncached
+				s.OutputT = usage.OutputTokens
+				s.ReasonT = usage.ReasoningOutputTokens
+				s.CacheR = usage.CachedInputTokens
+				s.CacheW = usage.CacheWriteInputTokens
+			case "agent_message":
+				s.Messages++
+			}
+		case "response_item":
+			var item struct {
+				Type string `json:"type"`
+				Name string `json:"name"`
+			}
+			if json.Unmarshal(entry.Payload, &item) != nil {
+				continue
+			}
+			if item.Type == "custom_tool_call" || item.Type == "function_call" {
+				name := item.Name
+				if name == "" {
+					name = "tool"
+				}
+				s.Tools[name]++
+				s.ToolTotal++
+			}
+		}
+	}
+
+	s.Provider = "openai"
+	s.Cost = codexCost(s.Model, s.InputT, s.OutputT, s.CacheR, s.CacheW)
+	s.Started = firstTS
+	s.LastAct = lastTS
+	if !firstTS.IsZero() && lastTS.After(firstTS) {
+		s.Duration = lastTS.Sub(firstTS)
+	}
+}
+
+// openaiPricing maps a model-id substring to OpenAI per-MTok USD rates
+// (standard tier, short context). Matching is by substring, longest match
+// first, so "gpt-5.6-sol" wins over "gpt-5".
+//
+// Scoped to the gpt-5 family, which is what Codex runs. Those models price
+// cached input at 0.1x input and cache writes at 1.25x, matching blendedCost.
+// Older families do NOT (gpt-4.1 caches at 0.25x, gpt-4o at 0.5x) and are
+// deliberately omitted rather than costed with the wrong multiplier.
+//
+// Long-context rates (roughly double) are not modelled: they apply above a
+// context length larger than the window Codex reports (258,400 for
+// gpt-5.6-sol), so a Codex turn cannot reach that tier.
+var openaiPricing = []struct {
+	substr string
+	in     float64 // USD per MTok input
+	out    float64 // USD per MTok output
+}{
+	{"gpt-5.6-sol", 5, 30},
+	{"gpt-5.6-terra", 2, 12},
+	{"gpt-5.6-luna", 0.2, 1.2},
+	{"gpt-5.6-cyber", 12.5, 75},
+	{"gpt-5.5-cyber", 12.5, 75},
+	{"gpt-5.5-pro", 30, 180},
+	{"gpt-5.5", 5, 30},
+	{"gpt-5.4-pro", 30, 180},
+	{"gpt-5.4-mini", 0.75, 4.5},
+	{"gpt-5.4-nano", 0.2, 1.25},
+	{"gpt-5.4", 2.5, 15},
+	{"gpt-5.3-codex", 1.75, 14},
+	{"gpt-5.2-pro", 21, 168},
+	{"gpt-5.2", 1.75, 14},
+	{"gpt-5.1", 1.25, 10},
+	{"gpt-5-pro", 15, 120},
+	{"gpt-5-mini", 0.25, 2},
+	{"gpt-5-nano", 0.05, 0.4},
+	{"gpt-5", 1.25, 10},
+}
+
+// openaiRates returns per-MTok rates for a model id, longest substring first.
+// ok is false for unknown models, which then show tokens with no cost.
+func openaiRates(model string) (in, out float64, ok bool) {
+	best := -1
+	for _, p := range openaiPricing {
+		if strings.Contains(model, p.substr) && len(p.substr) > best {
+			best = len(p.substr)
+			in, out = p.in, p.out
+			ok = true
+		}
+	}
+	return in, out, ok
+}
+
+// codexCost estimates the USD cost of a Codex session.
+func codexCost(model string, input, output, cacheRead, cacheWrite int) float64 {
+	in, out, ok := openaiRates(model)
+	if !ok {
+		return 0
+	}
+	return blendedCost(in, out, input, output, cacheRead, cacheWrite)
+}

--- a/cmd/token-dashboard/codex_test.go
+++ b/cmd/token-dashboard/codex_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Trimmed from a real `codex exec` rollout (Codex CLI 0.147.0): session_meta,
+// turn_context, one tool call, two agent messages, and two cumulative
+// token_count events.
+const codexRollout = `{"timestamp":"2026-08-11T04:51:33.000Z","type":"session_meta","payload":{"session_id":"sess-1","id":"sess-1","cwd":"/work/repo"}}
+{"timestamp":"2026-08-11T04:51:34.000Z","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}
+{"timestamp":"2026-08-11T04:51:35.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":18599,"cached_input_tokens":11008,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":18604},"model_context_window":258400}}}
+{"timestamp":"2026-08-11T04:51:36.000Z","type":"event_msg","payload":{"type":"agent_message"}}
+{"timestamp":"2026-08-11T04:51:40.000Z","type":"response_item","payload":{"type":"custom_tool_call","name":"exec"}}
+{"timestamp":"2026-08-11T04:51:45.000Z","type":"event_msg","payload":{"type":"agent_message"}}
+{"timestamp":"2026-08-11T04:52:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":38218,"cached_input_tokens":22016,"cache_write_input_tokens":0,"output_tokens":138,"reasoning_output_tokens":0,"total_tokens":38356},"model_context_window":258400}}}
+`
+
+// withCodexHome points CODEX_HOME at a temp dir holding one rollout.
+func withCodexHome(t *testing.T, name, body string) {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, "sessions", "2026", "08", "10")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("CODEX_HOME", home)
+}
+
+func TestReadCodexSession(t *testing.T) {
+	withCodexHome(t, "rollout-2026-08-10T21-51-33-sess-1.jsonl", codexRollout)
+
+	s := tokenStats{Tools: map[string]int{}}
+	readCodexSession("sess-1", &s)
+
+	// Cumulative totals: the LAST token_count wins rather than summing.
+	// input_tokens is inclusive of cached, so IN is reported uncached:
+	// 38218 - 22016 - 0 = 16202.
+	if s.InputT != 16202 {
+		t.Errorf("InputT = %d, want 16202", s.InputT)
+	}
+	if s.OutputT != 138 {
+		t.Errorf("OutputT = %d, want 138", s.OutputT)
+	}
+	if s.CacheR != 22016 {
+		t.Errorf("CacheR = %d, want 22016", s.CacheR)
+	}
+	if s.Model != "gpt-5.6-sol" {
+		t.Errorf("Model = %q, want gpt-5.6-sol", s.Model)
+	}
+	if s.Provider != "openai" {
+		t.Errorf("Provider = %q, want openai", s.Provider)
+	}
+	if s.Messages != 2 {
+		t.Errorf("Messages = %d, want 2", s.Messages)
+	}
+	if s.ToolTotal != 1 || s.Tools["exec"] != 1 {
+		t.Errorf("tools = %v (total %d), want exec×1", s.Tools, s.ToolTotal)
+	}
+	if s.Cwd != "/work/repo" {
+		t.Errorf("Cwd = %q, want /work/repo", s.Cwd)
+	}
+	if s.Duration.Seconds() != 30 {
+		t.Errorf("Duration = %v, want 30s", s.Duration)
+	}
+	// gpt-5.6-sol at $5/$30 per MTok, cache read 0.1x in:
+	// (16202*5 + 138*30 + 22016*0.5 + 0) / 1e6
+	want := (16202*5.0 + 138*30.0 + 22016*0.5) / 1e6
+	if s.Cost != want {
+		t.Errorf("Cost = %v, want %v", s.Cost, want)
+	}
+}
+
+func TestReadCodexSessionResolvesBySessionMeta(t *testing.T) {
+	// Filename carries no session id, so the session_meta fallback must find it.
+	withCodexHome(t, "rollout-2026-08-10T21-51-33-other.jsonl", codexRollout)
+
+	s := tokenStats{Tools: map[string]int{}}
+	readCodexSession("sess-1", &s)
+
+	if s.Model != "gpt-5.6-sol" {
+		t.Errorf("fallback lookup failed: Model = %q", s.Model)
+	}
+}
+
+func TestReadCodexSessionMissingRollout(t *testing.T) {
+	withCodexHome(t, "rollout-2026-08-10T21-51-33-sess-1.jsonl", codexRollout)
+
+	s := tokenStats{Tools: map[string]int{}}
+	readCodexSession("nope", &s)
+
+	if s.InputT != 0 || s.Model != "" || s.Messages != 0 {
+		t.Errorf("expected zero stats for unknown session, got %+v", s)
+	}
+}
+
+func TestOpenAIRates(t *testing.T) {
+	cases := []struct {
+		model  string
+		wantIn float64
+		wantOK bool
+	}{
+		// Longest match must win: every id below also contains "gpt-5".
+		{"gpt-5.6-sol", 5, true},
+		{"gpt-5.6-luna", 0.2, true},
+		{"gpt-5.3-codex", 1.75, true},
+		{"gpt-5.4-mini", 0.75, true},
+		{"gpt-5.4", 2.5, true},
+		{"gpt-5", 1.25, true},
+		// Deliberately absent: gpt-4.x caches at 0.25x/0.5x, not 0.1x, so
+		// blendedCost would misprice it. No rate is better than a wrong one.
+		{"gpt-4.1", 0, false},
+		{"gpt-4o", 0, false},
+		{"some-future-model", 0, false},
+		{"", 0, false},
+	}
+	for _, tc := range cases {
+		in, _, ok := openaiRates(tc.model)
+		if ok != tc.wantOK || in != tc.wantIn {
+			t.Errorf("openaiRates(%q) = (in=%v, ok=%v), want (in=%v, ok=%v)",
+				tc.model, in, ok, tc.wantIn, tc.wantOK)
+		}
+	}
+}

--- a/cmd/token-dashboard/main.go
+++ b/cmd/token-dashboard/main.go
@@ -62,6 +62,7 @@ var (
 	piBadge     = lipgloss.NewStyle().Foreground(purple).Bold(true)
 	ocBadge     = lipgloss.NewStyle().Foreground(green).Bold(true)
 	claudeBadge = lipgloss.NewStyle().Foreground(orange).Bold(true)
+	codexBadge  = lipgloss.NewStyle().Foreground(teal).Bold(true)
 
 	// Cost tiers
 	costLow   = lipgloss.NewStyle().Foreground(green)
@@ -336,6 +337,8 @@ func agentBadge(agent string) string {
 		return ocBadge.Render("opencode")
 	case "claude":
 		return claudeBadge.Render("claude")
+	case "codex":
+		return codexBadge.Render("codex")
 	default:
 		return labelStyle.Render(fallback(agent, "—"))
 	}
@@ -907,6 +910,9 @@ func extractStats(p paneEntry) tokenStats {
 	case "herdr:claude", "claude":
 		s.Source = "claude"
 		readClaudeSession(p.AgentSession.Value, p.Cwd, &s)
+	case "herdr:codex", "codex":
+		s.Source = "codex"
+		readCodexSession(p.AgentSession.Value, &s)
 	default:
 		if strings.HasSuffix(p.AgentSession.Value, ".jsonl") {
 			s.Source = "pi"
@@ -1029,16 +1035,24 @@ func claudeRates(model string) (in, out float64, ok bool) {
 	return in, out, ok
 }
 
+// blendedCost applies per-MTok input/output rates with the 0.1x cache-read and
+// 1.25x cache-write multipliers. Current Anthropic models and OpenAI's gpt-5
+// family both price cached input at 0.1x and cache writes at 1.25x of input, so
+// both providers share this arithmetic.
+func blendedCost(in, out float64, input, output, cacheRead, cacheWrite int) float64 {
+	return (float64(input)*in +
+		float64(output)*out +
+		float64(cacheRead)*0.1*in +
+		float64(cacheWrite)*1.25*in) / 1_000_000
+}
+
 // claudeCost estimates the USD cost of one assistant turn.
 func claudeCost(model string, input, output, cacheRead, cacheWrite int) float64 {
 	in, out, ok := claudeRates(model)
 	if !ok {
 		return 0
 	}
-	return (float64(input)*in +
-		float64(output)*out +
-		float64(cacheRead)*0.1*in +
-		float64(cacheWrite)*1.25*in) / 1_000_000
+	return blendedCost(in, out, input, output, cacheRead, cacheWrite)
 }
 
 // claudeProjectsRoot returns the Claude Code projects directory


### PR DESCRIPTION
Codex panes carry a Herdr `agent_session` with source `herdr:codex`, but `extractStats` has no case for it. They fall through to the `.jsonl` suffix check, fail it, and get dropped by `collectStats` entirely — so a Codex pane is invisible in the table and contributes nothing to the TOTAL row.

Adds `readCodexSession`, reading the rollout JSONL under `~/.codex/sessions/` (honouring `$CODEX_HOME`). The session id is matched on the rollout filename (`rollout-<ts>-<session-id>.jsonl`), falling back to reading the `session_meta` line when the name doesn't carry it.

```
  PANE        AGENT     STATUS    COST      MODEL          MSGS   TOOLS
  SHA-702     codex     ● working $0.10     gpt-5.6-sol    2      1
  SHA-681     claude    ● working $42.59    claude-opus-5  219    231
```

### Two things that differ from the existing sources

Both are handled explicitly rather than assumed, because getting either wrong is silent:

- **Codex reports cumulative totals on every `token_count` event**, so the last event wins rather than being summed the way Pi and Claude per-message usage is. Summing would inflate a long session enormously.
- **Codex's `input_tokens` is inclusive of `cached_input_tokens`**, unlike the other sources. The cached portion is subtracted so IN and CACHE mean the same thing for every agent and the totals row stays additive. Happy to flip this if you'd rather report the raw field — it's a one-line change, but it makes cross-agent totals misleading.

### Pricing

A second rate table, scoped to the **gpt-5 family** Codex runs. Those models price cached input at **0.1x** input and cache writes at **1.25x** — identical to the multipliers already applied to Anthropic models — so I extracted the arithmetic into `blendedCost` and both providers share it rather than duplicating the expression.

Older families are omitted on purpose: `gpt-4.1` caches at 0.25x and `gpt-4o` at 0.5x, so running them through these multipliers would be wrong. Unknown models already degrade to tokens-without-cost, which is the better failure. There's a test asserting they return no rate, so nobody "helpfully" adds them later without also fixing the multiplier.

Long-context rates (roughly double) are **not** modelled — they apply above a context length larger than the window Codex reports (258,400 for `gpt-5.6-sol`), so a Codex turn can't reach that tier.

### Testing

Fixture is trimmed from a **real `codex exec` rollout** (Codex CLI 0.147.0), not hand-written. Tests cover the happy path, `session_meta` fallback resolution, an unknown session, and rate lookup — including that **longest-match wins**, since every `gpt-5.x` id also contains `gpt-5` (the same substring-shadowing trap as the `opus-4` → `opus-4-8` bug in #2).

Verified against the untrimmed rollout on disk:

```
model="gpt-5.6-sol" in=16202 out=138 cacheR=22016 cost=$0.0962
```

which checks out by hand: (16202×5 + 138×30 + 22016×0.5) ÷ 1e6.

`go build`, `go vet`, `gofmt`, and `go test ./...` all clean.

Model comes from `turn_context.model` (falling back to `world_state.model`), messages count `agent_message` events, and tools count `custom_tool_call` / `function_call` response items. Codex also gets a badge colour alongside pi/opencode/claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)